### PR TITLE
Exclude tests from sdist to reduce size

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 prune corsikaio/_dev_version
 prune .github
+prune tests


### PR DESCRIPTION
Fixes #19 

For now, we just remove the tests and resources from the sdist to circumvent the upload size limit. I will look for a better solution (smaller test files, download, ..)