### PR TITLE
Add option to not parse blocks

### DIFF
--- a/corsikaio/file.py
+++ b/corsikaio/file.py
@@ -172,9 +172,6 @@ class CorsikaCherenkovFile(CorsikaFile):
         self.mmcs = mmcs
 
     def parse_data_blocks(self, data_bytes):
-        if not self.parse_blocks:
-            return _to_floatarray(data_bytes)
-
         photons = parse_cherenkov_photons(data_bytes)
         if not self.mmcs:
             return photons
@@ -198,7 +195,4 @@ class CorsikaParticleFile(CorsikaFile):
         self.EventClass = ParticleEvent
 
     def parse_data_blocks(self, data_bytes):
-        if not self.parse_blocks:
-            return _to_floatarray(data_bytes)
-
         return parse_particle_data(data_bytes)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 
 
 def test_version():
@@ -69,6 +70,22 @@ def test_particle_longi():
         e = next(f)
 
         assert e.header['event_number'] == 1
+
+
+def test_particle_no_parse():
+    from corsikaio import CorsikaParticleFile
+
+    with CorsikaParticleFile('tests/resources/corsika757_particle', parse_blocks=False) as f:
+        n_read = 0
+        for e in f:
+            n_read += 1
+            # second entry in header is event_number
+            assert e.header[1] == n_read
+            assert e.header.dtype == np.float32
+            assert len(e.header) == 273
+            assert e.particles.size % 273 == 0
+        assert n_read == 10
+
 
 
 def test_truncated(tmp_path):


### PR DESCRIPTION
When loading large files in-bulk, it's much faster to accumulate the arrays and then parse the low-level float arrays then parsing each event directly.

Added an option to just keep the float array in the event loop.