### PR TITLE
Fix reading of longitudinal blocks, fixes #24

### DIFF
--- a/corsikaio/subblocks/longitudinal.py
+++ b/corsikaio/subblocks/longitudinal.py
@@ -30,5 +30,5 @@ longitudinal_data_fields = [
     Field(10, "n_cherenkov", shape="f4"),
 ]
 
-longitudinal_header_dtype = build_dtype(longitudinal_header_fields)
-longitudinal_data_dtype = build_dtype(longitudinal_data_fields)
+longitudinal_header_dtype = build_dtype(longitudinal_header_fields, itemsize=None)
+longitudinal_data_dtype = build_dtype(longitudinal_data_fields, itemsize=None)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -67,9 +67,9 @@ def test_particle_longi():
     with CorsikaParticleFile('tests/resources/corsika757_particle') as f:
         assert f.run_end['n_events'] == 10
 
-        e = next(f)
-
-        assert e.header['event_number'] == 1
+        for i, e in enumerate(f, start=1):
+            assert e.header['event_number'] == i
+            assert np.all(e.longitudinal['vertical_depth'] == np.arange(20, 801, 20))
 
 
 def test_particle_no_parse():


### PR DESCRIPTION
fixes #24


This bug got introduced in #23, missing the itemsize=None meant that we immediately read the full block, not just the header information resulting in empty longitudinal profile in the event.