### PR TITLE
Chunked reading

### DIFF
--- a/corsikaio/file.py
+++ b/corsikaio/file.py
@@ -60,7 +60,6 @@ class CorsikaFile:
                 self._f.seek(-4, 2)
 
             self._f.seek(-BLOCK_SIZE_BYTES, 1)
-            # block = next(self._block_iter)
             block = self._f.read(BLOCK_SIZE_BYTES)
             while block[:4] != b'RUNE':
                 self._f.seek(-2 * BLOCK_SIZE_BYTES, 1)

--- a/corsikaio/file.py
+++ b/corsikaio/file.py
@@ -13,7 +13,7 @@ from .subblocks import (
 )
 from .subblocks.longitudinal import longitudinal_header_dtype
 from .subblocks.data import mmcs_cherenkov_photons_dtype
-from .io import iter_blocks, read_block, read_buffer_size, open_compressed
+from .io import iter_blocks, read_buffer_size, open_compressed
 
 from .constants import BLOCK_SIZE_BYTES, EVTH_VERSION_POSITION
 

--- a/corsikaio/file.py
+++ b/corsikaio/file.py
@@ -122,7 +122,8 @@ class CorsikaFile:
         pos = self._f.tell()
         self._f.seek(0)
 
-        block = next(self._block_iter)
+        block_iter = iter_blocks(self._f)
+        block = next(block_iter)
         event_header_data = bytearray()
         end_found = True
 
@@ -144,7 +145,7 @@ class CorsikaFile:
             elif block[:4] == b'EVTE':
                 end_found = True
 
-            block = next(self._block_iter)
+            block = next(block_iter)
 
         self._f.seek(pos)
 

--- a/corsikaio/io.py
+++ b/corsikaio/io.py
@@ -61,12 +61,10 @@ def iter_blocks(f, default_buffersize=BLOCK_SIZE_BYTES * 100):
 
 
     data = f.read(4)
-    print('FIRST 4 bytes:', data)
     f.seek(0)
     if data == b'RUNH':
         is_fortran_file = False
 
-    print("RECORDS:", is_fortran_file)
 
     
     record = 0
@@ -88,14 +86,12 @@ def iter_blocks(f, default_buffersize=BLOCK_SIZE_BYTES * 100):
 
 
         n_blocks = len(data) // BLOCK_SIZE_BYTES
-        print(n_blocks, BLOCK_SIZE_BYTES * n_blocks - len(data))
         for block in range(n_blocks):
-            print(f'Block {block}, record {record}')
             start = block * BLOCK_SIZE_BYTES
             stop = start + BLOCK_SIZE_BYTES
-            print(start, stop)
             block = data[start:stop]
-            print(block[:4])
+            if len(block) < BLOCK_SIZE_BYTES:
+                raise IOError("Read less bytes than expected, file seems to be truncated")
             yield block
 
         # read trailing record marker

--- a/corsikaio/io.py
+++ b/corsikaio/io.py
@@ -4,6 +4,10 @@ import struct
 from .constants import BLOCK_SIZE_BYTES
 
 
+#: buffersize for files not written as fortran sequential file
+DEFAULT_BUFFER_SIZE = BLOCK_SIZE_BYTES * 100
+
+
 def is_gzip(path):
     '''Test if a file is gzipped by reading its first two bytes and compare
     to the gzip marker bytes.
@@ -55,9 +59,9 @@ def read_buffer_size(path):
 RECORD_MARKER = struct.Struct('i')
 
 
-def iter_blocks(f, default_buffersize=BLOCK_SIZE_BYTES * 100):
+def iter_blocks(f):
     is_fortran_file = True
-    record_size = default_buffersize
+    buffer_size = DEFAULT_BUFFER_SIZE
 
 
     data = f.read(4)
@@ -72,9 +76,9 @@ def iter_blocks(f, default_buffersize=BLOCK_SIZE_BYTES * 100):
             if len(data) < RECORD_MARKER.size:
                 raise IOError("Read less bytes than expected, file seems to be truncated")
 
-            record_size, = RECORD_MARKER.unpack(data)
+            buffer_size, = RECORD_MARKER.unpack(data)
 
-        data = f.read(record_size)
+        data = f.read(buffer_size)
 
         n_blocks = len(data) // BLOCK_SIZE_BYTES
         for block in range(n_blocks):

--- a/corsikaio/io.py
+++ b/corsikaio/io.py
@@ -65,25 +65,16 @@ def iter_blocks(f, default_buffersize=BLOCK_SIZE_BYTES * 100):
     if data == b'RUNH':
         is_fortran_file = False
 
-
-    
-    record = 0
     while True:
-        record += 1
         # for the fortran-chunked output, we need to read the record size
         if is_fortran_file:
             data = f.read(RECORD_MARKER.size)
-            if len(data) == 0:
-                yield b''
-                return
+            if len(data) < RECORD_MARKER.size:
+                raise IOError("Read less bytes than expected, file seems to be truncated")
 
             record_size, = RECORD_MARKER.unpack(data)
 
         data = f.read(record_size)
-        if len(data) == 0:
-            yield b''
-            return
-
 
         n_blocks = len(data) // BLOCK_SIZE_BYTES
         for block in range(n_blocks):

--- a/corsikaio/io.py
+++ b/corsikaio/io.py
@@ -6,6 +6,8 @@ from .constants import BLOCK_SIZE_BYTES
 
 #: buffersize for files not written as fortran sequential file
 DEFAULT_BUFFER_SIZE = BLOCK_SIZE_BYTES * 100
+#: struct definition of the fortran record marker
+RECORD_MARKER = struct.Struct('i')
 
 
 def is_gzip(path):
@@ -46,17 +48,14 @@ def read_buffer_size(path):
     size of the CORSIKA buffer in bytes
     '''
     with open_compressed(path) as f:
-        data = f.read(4)
+        data = f.read(RECORD_MARKER.size)
 
         if data == b'RUNH':
             return None
 
-        buffer_size, = struct.unpack('I', data)
+        buffer_size, = RECORD_MARKER.unpack(data)
 
     return buffer_size
-
-
-RECORD_MARKER = struct.Struct('i')
 
 
 def iter_blocks(f):

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ zstd =
 	zstandard
 tests =
 	pytest
+    scipy
 all =
 	%(zstd)s
 	%(tests)s


### PR DESCRIPTION
This provides a pretty decent speed-up (at least for the parse_blocks=False cases),
on an 800 MB file with 400000 showers:

```
# this branch:
$ python time_read.py 
1.973 s
# main branch:
$ python time_read.py 
2.915 s
```

where time_read is:

```
from corsikaio import CorsikaParticleFile
import time



t0 = time.perf_counter()
with CorsikaParticleFile("./tmp/DAT000000", parse_blocks=False) as f:
    for e in f:
        pass

print(f"{time.perf_counter() - t0:.3f} s")
```

and `tmp` is a ramdisk