### PR TITLE
Add all functions to __all__ list

### DIFF
--- a/corsikaio/subblocks/__init__.py
+++ b/corsikaio/subblocks/__init__.py
@@ -13,7 +13,12 @@ from .longitudinal import longitudinal_data_dtype
 from ..constants import RUNH_VERSION_POSITION, EVTH_VERSION_POSITION
 
 __all__ = [
+    "get_units_from_fields",
+    "get_version",
+    "parse_data_block",
+    "parse_event_end",
     "parse_event_header",
+    "parse_run_end",
     "parse_run_header",
     "parse_cherenkov_photons",
     "parse_particle_data",


### PR DESCRIPTION
I propose adding all the functions in the __init__ file to the __all__ list such that we can import those functions from outside world. Please let me know if an alternative solution would be preferred. Thanks!

The motivation for doing that came from the following error we got in gammasim-tools:
```
ImportError while loading conftest '/home/runner/work/gammasim-tools/gammasim-tools/tests/conftest.py'.
tests/conftest.py:12: in <module>
    from simtools.corsika.corsika_output import CorsikaOutput
simtools/corsika/corsika_output.py:11: in <module>
    from corsikaio.subblocks import event_header, get_units_from_fields, run_header
E   ImportError: cannot import name 'get_units_from_fields' from 'corsikaio.subblocks' (/usr/share/miniconda/envs/gammasim-tools-dev/lib/python3.9/site-packages/corsikaio/subblocks/__init__.py)
Error: Process completed with exit code 4.
```