### PR TITLE
Fix numpy deprecation warning

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -65,18 +65,18 @@ def fortran_raw_dummy_file(tmp_path):
 
 
     blocks = []
-    data[0] = np.frombuffer(b'RUNH', dtype=np.float32)
+    data[0] = np.frombuffer(b'RUNH', dtype=np.float32)[0]
     blocks.append(data.copy())
 
     for _ in range(5):
-        data[0] = np.frombuffer(b'EVTH', dtype=np.float32)
+        data[0] = np.frombuffer(b'EVTH', dtype=np.float32)[0]
         blocks.append(data.copy())
         for _ in range(3):
             data[0] = 0.0
             blocks.append(data.copy())
-        data[0] = np.frombuffer(b'EVTE', dtype=np.float32)
+        data[0] = np.frombuffer(b'EVTE', dtype=np.float32)[0]
         blocks.append(data.copy())
-    data[0] = np.frombuffer(b'RUNE', dtype=np.float32)
+    data[0] = np.frombuffer(b'RUNE', dtype=np.float32)[0]
     blocks.append(data.copy())
 
     blocks_per_record = 5


### PR DESCRIPTION
Fixes deprecation warnings during the tests:

```
 /home/mnoethe/Uni/CTA/pycorsikaio/tests/test_io.py:79: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    data[0] = np.frombuffer(b'RUNE', dtype=np.float32)
```